### PR TITLE
update the remote verify process

### DIFF
--- a/lib/passport-browserid/strategy.js
+++ b/lib/passport-browserid/strategy.js
@@ -92,8 +92,7 @@ Strategy.prototype.authenticate = function(req) {
   headers['Content-Length'] = query.length;
   
   var options = {
-    host: 'browserid.org',
-    port: 443,
+    host: 'verifier.login.persona.org',
     path: '/verify',
     method: 'POST',
     headers: headers


### PR DESCRIPTION
update the remote verify process according to the [official Mozilla documentation](https://developer.mozilla.org/en-US/docs/Persona/Remote_Verification_API?redirectlocale=en-US&redirectslug=BrowserID%2FRemote_Verification_API), because with the previous host and port was failing with "invalid assertion variables"
