### PR TITLE
The .getVerifiedEmail() function has been replaced by .get()

### DIFF
--- a/examples/signin/views/login.ejs
+++ b/examples/signin/views/login.ejs
@@ -5,7 +5,7 @@
 <img src="https://browserid.org/i/sign_in_red.png" id="browserid"/>
 <script>
   $("#browserid").click(function(){
-    navigator.id.getVerifiedEmail(function(assertion) {
+    navigator.id.get(function(assertion) {
       if (assertion) {
         $("input").val(assertion);
         $("form").submit();


### PR DESCRIPTION
Making this change will eliminate a console warning.
